### PR TITLE
fix: update regex in cmdtab.json to support patch versioning

### DIFF
--- a/bucket/cmdtab.json
+++ b/bucket/cmdtab.json
@@ -32,7 +32,7 @@
     "checkver": {
         "url": "https://api.github.com/repos/stianhoiland/cmdtab/releases",
         "jsonpath": "$..tag_name",
-        "regex": "v(\\d+\\.\\d+)",
+        "regex": "v(\\d+\\.\\d+\\.*\\d*)",
         "replace": "${1}"
     },
     "autoupdate": {


### PR DESCRIPTION
Update regex in the cmdtab manifest to support semver patch versioning.